### PR TITLE
Add rating tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ Just to be clear, I'm not planning to replicate the actual cases in the full box
 https://agonizingfool.github.io/SHCD-Demo/
 
 Join me on my Discord: https://discord.gg/sfrkpCPj
+
+## Running tests
+
+The repository includes a small Node.js test that verifies the score rating
+logic. Run it with the following command:
+
+```bash
+node tests/getRating.test.js
+```

--- a/score.js
+++ b/score.js
@@ -191,3 +191,8 @@ function getRating(score) {
     // Score 0 to 4 or less
     return "At least you tried.";
 }
+
+// Export for Node.js testing environment
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { getRating };
+}

--- a/tests/getRating.test.js
+++ b/tests/getRating.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { getRating } = require('../score.js');
+
+const cases = [
+  { score: 105, expected: 'You surpassed the master!' },
+  { score: 104, expected: 'Excellent!' },
+  { score: 75, expected: 'Excellent!' },
+  { score: 74, expected: 'Good!' },
+  { score: 35, expected: 'Good!' },
+  { score: 34, expected: 'Okay.' },
+  { score: 5, expected: 'Okay.' },
+  { score: 4, expected: 'At least you tried.' },
+  { score: 0, expected: 'At least you tried.' }
+];
+
+cases.forEach(({ score, expected }) => {
+  assert.strictEqual(
+    getRating(score),
+    expected,
+    `score ${score} should be "${expected}"`
+  );
+});
+
+console.log('All tests passed!');
+


### PR DESCRIPTION
## Summary
- export `getRating` for testing
- create `tests/getRating.test.js` covering rating boundaries
- document how to run the tests

## Testing
- `node tests/getRating.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68425c140edc83218a840d10a8744ddf